### PR TITLE
Support vg.up call for latest python-vagrant

### DIFF
--- a/library/vagrant
+++ b/library/vagrant
@@ -190,7 +190,7 @@ class VagrantWrapper(object):
             vgn = d['vagrant_name']
             status = self.vg.status(vgn)
             if status != 'running':
-                self.vg.up(False, d['vagrant_name'])
+                self.vg.up(False, vm_name=d['vagrant_name'])
                 changed =True
                 
         ad = self._build_instance_array_for_ansible(vm_name)


### PR DESCRIPTION
The call to "up" vagrant has changed to accomodate the provisioner as the
second argument and the vm_name as the third argument. Fixed this by passing
vm_name as a named parameter.

The commit related to this is https://github.com/todddeluca/python-vagrant/commit/bc344ba108ae71d6e2dc48d4f469db5d830765f8
